### PR TITLE
Correct usage information for not expected argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ optional arguments:
   -e EXPECTED, --expected EXPECTED
                         Check expected state (default to None)
   -n NOTEXPECTED, --notexpected NOTEXPECTED
-                        Check expected state (default to None)
+                        Check not expected state (default to None)
   -w WARNING, --warning WARNING
                         Check if above threshold (warning, default to None)
   -c CRITICAL, --critical CRITICAL

--- a/examples/hassio.conf
+++ b/examples/hassio.conf
@@ -10,7 +10,7 @@ object CheckCommand "hassio" {
 		}
 		"-P" = {
 			value = "$hassio_port$"
-			description = "Port number (default: 443)"
+			description = "Port number (default: 8123)"
 		}
 		"-S" = {
 			set_if = "$hassio_ssl$"


### PR DESCRIPTION
Typo in usage information for not expected argument
Correct the default port number in the example